### PR TITLE
iOS: concurrent downloads + fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ API provides an advanced file download functionality that persists beyond app te
  * Android
  
 **Quirks**
- * Concurrent background downloads are NOT currently supported on iOS.
  * If a download operation was completed when the application was in the background, onSuccess callback is called when the application become active.
  * If a download operation was completed when the application was closed, onSuccess callback is called right after the first startAsync() is called for the same uri, as if the file has been downloaded immediatly.
  * A new download operation for the same uri resumes a pending download instead of triggering a new one. If no pending downloads found for the uri specified, a new download is started, the target file will be automatically overwritten once donwload is completed.

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-background-download"
-      version="0.1.1">
+      version="0.1.2">
     <name>Background Download</name>
 
     <description>Cordova Background Download Plugin</description>

--- a/src/ios/BackgroundDownload.h
+++ b/src/ios/BackgroundDownload.h
@@ -24,14 +24,23 @@
 // the download wilcontinue until it completes.
 @interface BackgroundDownload : CDVPlugin <NSURLSessionDownloadDelegate>
 
-@property NSString *targetFile;
-@property NSString *downloadUri;
-@property NSString *callbackId;
+
+@property NSMutableDictionary * downloadList;
 
 @property (nonatomic) NSURLSession *session;
-@property (nonatomic) NSURLSessionDownloadTask *downloadTask;
+//@property (nonatomic) NSURLSessionDownloadTask *downloadTask;
 
 - (void)startAsync:(CDVInvokedUrlCommand*)command;
 - (void)stop:(CDVInvokedUrlCommand*)command;
+
+@end
+
+
+@interface DownloadHolder : NSObject
+
+@property NSString *targetFile;
+@property NSString *downloadUri;
+@property NSString *callbackId;
+@property NSURLSessionDownloadTask *downloadTask;
 
 @end

--- a/src/ios/BackgroundDownload.m
+++ b/src/ios/BackgroundDownload.m
@@ -33,7 +33,10 @@
     
     self.callbackId = command.callbackId;
     
-    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:self.downloadUri]];
+    NSURL *url = [NSURL URLWithString: [[self.downloadUri stringByAddingPercentEscapesUsingEncoding: NSUTF8StringEncoding]
+                                        stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]]];
+    
+    NSURLRequest *request = [NSURLRequest requestWithURL:url];
     
     ignoreNextError = NO;
     

--- a/src/ios/BackgroundDownload.m
+++ b/src/ios/BackgroundDownload.m
@@ -25,8 +25,6 @@
 }
 
 @synthesize session;
-//@synthesize downloadTask;
-
 
 -(DownloadHolder*) holderWithUrl:(NSString* ) downloadUri {
     if(_downloadList) {
@@ -89,30 +87,6 @@
                     }
                 }
     }];
-    
-//    self.targetFile = [command.arguments objectAtIndex:1];
-//    
-//    self.callbackId = command.callbackId;
-    
-    
-    
- 
-    
-//    session = [self backgroundSession];
-//    
-//    Download * download = [[Download alloc] init];
-//    download.url = 
-//    
-//    [session getTasksWithCompletionHandler:^(NSArray *dataTasks, NSArray *uploadTasks, NSArray *downloadTasks) {
-//        if (downloadTasks.count > 0) {
-//            downloadTask = downloadTasks[0];
-//        } else {
-//            downloadTask = [session downloadTaskWithRequest:request];
-//            objc_setAssociatedObject(downloadTask, @"callbackId", command.callbackId, OBJC_ASSOCIATION_COPY);
-//        }
-//        [downloadTask resume];
-//    }];
-    
 }
 
 - (NSURLSession *)backgroundSession
@@ -122,7 +96,7 @@
     dispatch_once(&onceToken, ^{
         NSURLSessionConfiguration *config = [NSURLSessionConfiguration backgroundSessionConfiguration:@"com.cordova.plugin.BackgroundDownload.BackgroundSession"];
         backgroundSession = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:nil];
-        [backgroundSession invalidateAndCancel];
+        //[backgroundSession invalidateAndCancel];
     });
     return backgroundSession;
 }
@@ -138,7 +112,6 @@
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Arg was null"];
     }
     
-    //[downloadTask cancel];
     DownloadHolder * holder = [self holderWithUrl:myarg];
     if(holder){
         if(holder.downloadTask.state == NSURLSessionTaskStateCompleted) {
@@ -169,7 +142,6 @@
 }
 
 -(void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error {
-
     
     if (ignoreNextError) {
         ignoreNextError = NO;
@@ -185,9 +157,6 @@
             // this happens when application is closed when there is pending download, so we try to resume it
             if (resumeData != nil) {
                 ignoreNextError = YES;
-//                [downloadTask cancel];
-//                downloadTask = [self.session downloadTaskWithResumeData:resumeData];
-//                [downloadTask resume];
                 return;
             }
         }
@@ -197,7 +166,6 @@
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
         [self.commandDelegate sendPluginResult:pluginResult callbackId: holder.callbackId];
     }
-    //删除
     @synchronized (_downloadList) {
         [_downloadList removeObjectForKey:holder.downloadUri];
     }
@@ -209,7 +177,6 @@
         NSLog(@"didFinishDownloadingToURL %@", holder.downloadUri);
         NSFileManager *fileManager = [NSFileManager defaultManager];
     
-        //NSURL *targetURL = [NSURL URLWithString:_targetFile];
         NSURL *targetURL = [NSURL URLWithString:holder.targetFile];
     
         [fileManager removeItemAtPath:targetURL.path error: nil];
@@ -219,6 +186,5 @@
 @end
 
 @implementation DownloadHolder
-
 
 @end

--- a/src/ios/BackgroundDownload.m
+++ b/src/ios/BackgroundDownload.m
@@ -89,17 +89,27 @@
     }];
 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 - (NSURLSession *)backgroundSession
 {
     static NSURLSession *backgroundSession = nil;
     static dispatch_once_t onceToken;
+    
+    NSURLSessionConfiguration *config;
+    BOOL iOS8OrNewer = [[[UIDevice currentDevice] systemVersion] floatValue] >= 8.0;
+    if (iOS8OrNewer) {
+        config = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:@"com.cordova.plugin.BackgroundDownload.BackgroundSession"];
+    } else {
+        config = [NSURLSessionConfiguration backgroundSessionConfiguration:@"com.cordova.plugin.BackgroundDownload.BackgroundSession"];
+    }
+    
     dispatch_once(&onceToken, ^{
-        NSURLSessionConfiguration *config = [NSURLSessionConfiguration backgroundSessionConfiguration:@"com.cordova.plugin.BackgroundDownload.BackgroundSession"];
         backgroundSession = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:nil];
-        //[backgroundSession invalidateAndCancel];
     });
     return backgroundSession;
 }
+#pragma GCC diagnostic pop
 
 - (void)stop:(CDVInvokedUrlCommand*)command
 {

--- a/src/ios/BackgroundDownload.m
+++ b/src/ios/BackgroundDownload.m
@@ -18,35 +18,97 @@
  */
 
 #import "BackgroundDownload.h"
+#import <objc/runtime.h>
 
 @implementation BackgroundDownload {
     bool ignoreNextError;
 }
 
 @synthesize session;
-@synthesize downloadTask;
+//@synthesize downloadTask;
+
+
+-(DownloadHolder*) holderWithUrl:(NSString* ) downloadUri {
+    if(_downloadList) {
+        return [_downloadList valueForKey:downloadUri];
+    }
+    return nil;
+}
+
+
+
+-(DownloadHolder*) holderWithTask:(NSURLSessionTask* ) task {
+    if(_downloadList) {
+        @synchronized (_downloadList) {
+            for (NSInteger i = 0, icount = _downloadList.count; i < icount; i ++) {
+                DownloadHolder * download = _downloadList.allValues[i];
+                if(download.downloadTask == task) {
+                    return  download;
+                }
+            }
+        }
+  
+    }
+    return nil;
+}
 
 - (void)startAsync:(CDVInvokedUrlCommand*)command
 {
-    self.downloadUri = [command.arguments objectAtIndex:0];
-    self.targetFile = [command.arguments objectAtIndex:1];
     
-    self.callbackId = command.callbackId;
+    if(!_downloadList) {
+        _downloadList = [[NSMutableDictionary alloc] init];
+    }
     
-    NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:self.downloadUri]];
+    NSString * downloadUri = [command.arguments objectAtIndex:0];
+    DownloadHolder * task = [self holderWithUrl:downloadUri];
+    if(!task) {
+        task = [[DownloadHolder alloc] init];
+        task.downloadUri = downloadUri;
+        task.targetFile = [command.arguments objectAtIndex:1];
+        task.callbackId = command.callbackId;
+        NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString: task.downloadUri]];
+        session = [self backgroundSession];
+        task.downloadTask = [session downloadTaskWithRequest:request];
+        @synchronized (_downloadList){
+            [_downloadList setValue:task forKey:task.downloadUri];
+        }
+        [task.downloadTask resume];
+    }
+    else {
+        [task.downloadTask resume];
+    }
     
     ignoreNextError = NO;
-    
-    session = [self backgroundSession];
-    
     [session getTasksWithCompletionHandler:^(NSArray *dataTasks, NSArray *uploadTasks, NSArray *downloadTasks) {
-        if (downloadTasks.count > 0) {
-            downloadTask = downloadTasks[0];
-        } else {
-            downloadTask = [session downloadTaskWithRequest:request];
-        }
-        [downloadTask resume];
+                if (downloadTasks.count > 0) {
+                    for (NSInteger i = 0, icount = downloadTasks.count; i < icount; i ++) {
+                        [downloadTasks[i] resume];
+                    }
+                }
     }];
+    
+//    self.targetFile = [command.arguments objectAtIndex:1];
+//    
+//    self.callbackId = command.callbackId;
+    
+    
+    
+ 
+    
+//    session = [self backgroundSession];
+//    
+//    Download * download = [[Download alloc] init];
+//    download.url = 
+//    
+//    [session getTasksWithCompletionHandler:^(NSArray *dataTasks, NSArray *uploadTasks, NSArray *downloadTasks) {
+//        if (downloadTasks.count > 0) {
+//            downloadTask = downloadTasks[0];
+//        } else {
+//            downloadTask = [session downloadTaskWithRequest:request];
+//            objc_setAssociatedObject(downloadTask, @"callbackId", command.callbackId, OBJC_ASSOCIATION_COPY);
+//        }
+//        [downloadTask resume];
+//    }];
     
 }
 
@@ -55,8 +117,9 @@
     static NSURLSession *backgroundSession = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSURLSessionConfiguration *config = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:@"com.cordova.plugin.BackgroundDownload.BackgroundSession"];
+        NSURLSessionConfiguration *config = [NSURLSessionConfiguration backgroundSessionConfiguration:@"com.cordova.plugin.BackgroundDownload.BackgroundSession"];
         backgroundSession = [NSURLSession sessionWithConfiguration:config delegate:self delegateQueue:nil];
+        [backgroundSession invalidateAndCancel];
     });
     return backgroundSession;
 }
@@ -72,12 +135,26 @@
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:@"Arg was null"];
     }
     
-    [downloadTask cancel];
-    
+    //[downloadTask cancel];
+    DownloadHolder * holder = [self holderWithUrl:myarg];
+    if(holder){
+        if(holder.downloadTask.state == NSURLSessionTaskStateCompleted) {
+            @synchronized (_downloadList){
+                [_downloadList removeObjectForKey: holder.downloadUri];
+            }
+        }
+        else {
+            [holder.downloadTask cancel];
+        }
+       
+    }
     [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
+    
 }
 
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didWriteData:(int64_t)bytesWritten totalBytesWritten:(int64_t)totalBytesWritten totalBytesExpectedToWrite:(int64_t)totalBytesExpectedToWrite {
+    DownloadHolder * holder = [self holderWithTask:downloadTask];
+    if(holder == nil) return;
     NSMutableDictionary* progressObj = [NSMutableDictionary dictionaryWithCapacity:1];
     [progressObj setObject:[NSNumber numberWithInteger:totalBytesWritten] forKey:@"bytesReceived"];
     [progressObj setObject:[NSNumber numberWithInteger:totalBytesExpectedToWrite] forKey:@"totalBytesToReceive"];
@@ -85,15 +162,19 @@
     [resObj setObject:progressObj forKey:@"progress"];
     CDVPluginResult* result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:resObj];
     result.keepCallback = [NSNumber numberWithInteger: TRUE];
-    [self.commandDelegate sendPluginResult:result callbackId:self.callbackId];
+    [self.commandDelegate sendPluginResult:result callbackId: holder.callbackId];
 }
 
 -(void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error {
+
+    
     if (ignoreNextError) {
         ignoreNextError = NO;
         return;
     }
-    
+    DownloadHolder * holder = [self holderWithTask:task];
+    if(holder == nil) return;
+    NSLog(@"didCompleteWithError %@", holder.downloadUri);
     if (error != nil) {
         if ((error.code == -999)) {
             NSData* resumeData = [[error userInfo] objectForKey:NSURLSessionDownloadTaskResumeData];
@@ -101,26 +182,40 @@
             // this happens when application is closed when there is pending download, so we try to resume it
             if (resumeData != nil) {
                 ignoreNextError = YES;
-                [downloadTask cancel];
-                downloadTask = [self.session downloadTaskWithResumeData:resumeData];
-                [downloadTask resume];
+//                [downloadTask cancel];
+//                downloadTask = [self.session downloadTaskWithResumeData:resumeData];
+//                [downloadTask resume];
                 return;
             }
         }
         CDVPluginResult* errorResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsString:[error localizedDescription]];
-        [self.commandDelegate sendPluginResult:errorResult callbackId:self.callbackId];
+        [self.commandDelegate sendPluginResult:errorResult callbackId: holder.callbackId];
     } else {
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
-        [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackId];
+        [self.commandDelegate sendPluginResult:pluginResult callbackId: holder.callbackId];
+    }
+    //删除
+    @synchronized (_downloadList) {
+        [_downloadList removeObjectForKey:holder.downloadUri];
     }
 }
 
 - (void)URLSession:(NSURLSession *)session downloadTask:(NSURLSessionDownloadTask *)downloadTask didFinishDownloadingToURL:(NSURL *)location {
-    NSFileManager *fileManager = [NSFileManager defaultManager];
+    DownloadHolder * holder = [self holderWithTask:downloadTask];
+    if(holder){
+        NSLog(@"didFinishDownloadingToURL %@", holder.downloadUri);
+        NSFileManager *fileManager = [NSFileManager defaultManager];
     
-    NSURL *targetURL = [NSURL URLWithString:_targetFile];
+        //NSURL *targetURL = [NSURL URLWithString:_targetFile];
+        NSURL *targetURL = [NSURL URLWithString:holder.targetFile];
     
-    [fileManager removeItemAtPath:targetURL.path error: nil];
-    [fileManager createFileAtPath:targetURL.path contents:[fileManager contentsAtPath:[location path]] attributes:nil];
+        [fileManager removeItemAtPath:targetURL.path error: nil];
+        [fileManager createFileAtPath:targetURL.path contents:[fileManager contentsAtPath:[location path]] attributes:nil];
+    }
 }
+@end
+
+@implementation DownloadHolder
+
+
 @end


### PR DESCRIPTION
I fixed problems with complex download URLs (my requests contain JSON strings).
Also, I merged (and fixed) @loyabe's patch to support concurrent downloads in iOS.